### PR TITLE
Saving model args and fixed tensor squeezing

### DIFF
--- a/model.py
+++ b/model.py
@@ -182,7 +182,7 @@ class SentenceVAE(nn.Module):
 
         if mode == 'greedy':
             _, sample = torch.topk(dist, 1, dim=-1)
-        sample = sample.squeeze()
+        sample = sample.reshape(-1)
 
         return sample
 


### PR DESCRIPTION
I am currently playing around with VAE model using this repo. I've implemented two small changes that were helpful to me for using model that I trained:

1. Model args saving along with args in order to easily load it later on.
2. Changed `sample = sample.squeeze` to `sample = sample.reshape(-1)` in `model.py`, since squeezing caused degeneration of tensor to zero dimensions when batch size was 1 during inference.